### PR TITLE
Fix CPU typo

### DIFF
--- a/top/info.plist
+++ b/top/info.plist
@@ -138,7 +138,7 @@
 	<key>createdby</key>
 	<string>Zhao Cai</string>
 	<key>description</key>
-	<string>List/Kill Top Processes by Memory, Cpu or IO Usage</string>
+	<string>List/Kill Top Processes by Memory, CPU or IO Usage</string>
 	<key>disabled</key>
 	<false/>
 	<key>name</key>


### PR DESCRIPTION
In the Workflow's description, it said `Cpu`, which should be `CPU`.
![screen shot 2014-05-30 at 11 32 02 am](https://cloud.githubusercontent.com/assets/3687851/3132469/96243376-e80f-11e3-9852-cd69460d8e94.png)
