### PR TITLE
Fix case for Glance where there is no fan speed

### DIFF
--- a/top/glance.rb
+++ b/top/glance.rb
@@ -77,12 +77,12 @@ class Glance
   def add_fan_speed_item(left, right)
     if left and right
       fan_speed = (left + right) / 2
+    elsif left.nil? && right.nil?
+      return
     elsif left.nil?
       fan_speed = right
     elsif right.nil?
       fan_speed = left
-    else
-      return
     end
 
     if fan_speed < 3500


### PR DESCRIPTION
Fixes issue #12, where the else statement wasn't being reached.

```
E, [2016-07-03 13:04:13 #6209] ERROR -- me.zhaowu.top: A fatal error has occurred. You may seek help in the Alfred supporting site, forum or raise an issue in the bug tracking site.
  #<NoMethodError: undefined method `<' for nil:NilClass>
  ./glance.rb:88:in `add_fan_speed_item'
./glance.rb:74:in `collect_temperature'
./glance.rb:48:in `collect'
./glance.rb:315:in `generate_feedback'
./glance.rb:324:in `block in <main>'
/Users/..../bundle/ruby/2.0.0/gems/alfred-workflow-2.0.5/lib/alfred.rb:82:in `with_friendly_error'
```
